### PR TITLE
feat: Migrate from Terraform Cloud to S3 backend

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,81 @@
+name: Terraform
+
+on:
+  push:
+    branches: [master]
+    paths: ['terraform/**', 'lambda/**']
+  pull_request:
+    branches: [master]
+    paths: ['terraform/**', 'lambda/**']
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  TF_DIR: terraform
+  AWS_REGION: us-east-1
+
+jobs:
+  terraform:
+    name: Terraform
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.TF_DIR }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.5.7"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -no-color -input=false
+        continue-on-error: true
+        env:
+          TF_VAR_api_access_token: ${{ secrets.API_ACCESS_TOKEN }}
+          TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
+          TF_VAR_supabase_url: ${{ secrets.SUPABASE_URL }}
+          TF_VAR_supabase_anon_key: ${{ secrets.SUPABASE_ANON_KEY }}
+
+      - name: Comment PR with Plan
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const plan = `${{ steps.plan.outputs.stdout }}`;
+            const truncated = plan.length > 60000 ? plan.substring(0, 60000) + '\n\n... (truncated)' : plan;
+            const body = `### Terraform Plan 📋\n\`\`\`\n${truncated}\n\`\`\`\n*Plan: ${{ steps.plan.outcome }}*`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        run: terraform apply -auto-approve -input=false
+        env:
+          TF_VAR_api_access_token: ${{ secrets.API_ACCESS_TOKEN }}
+          TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
+          TF_VAR_supabase_url: ${{ secrets.SUPABASE_URL }}
+          TF_VAR_supabase_anon_key: ${{ secrets.SUPABASE_ANON_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,10 @@
-# Local .terraform directories
-**/.terraform/*
-
-# .tfstate files
+# Terraform
 *.tfstate
-*.tfstate.*
+*.tfstate.backup
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+*.auto.tfvars
 
-# Crash log files
-crash.log
-crash.*.log
-
-# Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
-# to change depending on the environment.
-*.tfvars
-*.tfvars.json
-
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
-override.tf
-override.tf.json
-*_override.tf
-*_override.tf.json
-
-# Ignore transient lock info files created by terraform apply
-.terraform.tfstate.lock.info
-
-# Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
-
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
-
-# Ignore CLI configuration files
-.terraformrc
-terraform.rc
+# Lambda packages
+lambda/**/*.zip

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.75"
   hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
     "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  backend "remote" {
-    organization = "Domjgiordano"
-
-    workspaces {
-      name = "xomper-infrastructure"
-    }
+  backend "s3" {
+    bucket         = "xomware-terraform-state"
+    key            = "xomper/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "xomware-terraform-locks"
+    encrypt        = true
   }
 }
 

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -7,7 +7,5 @@ terraform {
   }
 }
 provider "aws" {
-  access_key = var.access_key
-  secret_key = var.secret_key
-  region     = var.aws_region
+  region = var.aws_region
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,16 +3,6 @@ variable "app_name" {
   default     = "xomper"
 }
 
-variable "access_key" {
-  description = "AWS access key."
-  sensitive   = true
-}
-
-variable "secret_key" {
-  description = "AWS secret key."
-  sensitive   = true
-}
-
 variable "domain_suffix" {
   description = "Suffix for the domain of the app."
   default     = ".xomware.com"


### PR DESCRIPTION
## Summary
Migrates xomper-infrastructure from Terraform Cloud to self-managed S3 state backend.

## Changes
- **Backend:** `remote` → `s3` (bucket: `xomware-terraform-state`, key: `xomper/terraform.tfstate`)
- **State locking:** DynamoDB table `xomware-terraform-locks`
- **Provider auth:** Removed hardcoded `access_key`/`secret_key` — uses AWS CLI profile or env vars
- **CI/CD:** GitHub Actions workflow (`terraform plan` on PR, `terraform apply` on merge)

## GitHub Secrets Needed
Settings → Secrets → Actions:
- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
   - `api_access_token` → `TF_VAR_...`
   - `api_secret_key` → `TF_VAR_...`
   - `supabase_url` → `TF_VAR_...`
   - `supabase_anon_key` → `TF_VAR_...`

## State
✅ Already uploaded to S3