### PR TITLE
cost: upgrade WAF to v2.0.0 (4→2 rule groups)

### DIFF
--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -1,6 +1,6 @@
 # CloudFront WAF (must be CLOUDFRONT scope)
 module "waf_cloudfront" {
-  source   = "git::https://github.com/domgiordano/waf.git?ref=v1.1.0"
+  source   = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
   app_name = "${var.app_name}-cloudfront"
   scope    = "CLOUDFRONT"
   tags     = local.standard_tags
@@ -8,7 +8,7 @@ module "waf_cloudfront" {
 
 # API Gateway WAF (REGIONAL scope)
 module "waf_api_gateway" {
-  source     = "git::https://github.com/domgiordano/waf.git?ref=v1.1.0"
+  source     = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
   app_name   = "${var.app_name}-api-gateway"
   scope      = "REGIONAL"
   rate_limit = 2000


### PR DESCRIPTION
Upgrade both WAF module sources from domgiordano/waf v1.1.0 to Xomware/waf v2.0.0.

**Changes:**
- Drop SQLi and KnownBadInputs managed rule groups
- Keep IP Reputation + Common Rules (2 rule groups instead of 4)
- Matches xomware-infrastructure WAF configuration

**Cost savings:** ~$2/month per WAF ACL