### PR TITLE
cost: consume shared WAF ACLs

### DIFF
--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -1,22 +1,18 @@
-# CloudFront WAF (must be CLOUDFRONT scope)
-module "waf_cloudfront" {
-  source   = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
-  app_name = "${var.app_name}-cloudfront"
-  scope    = "CLOUDFRONT"
-  tags     = local.standard_tags
+#**********************
+# WAF (shared from xomware-infrastructure)
+# Consumes shared WAF ACL ARNs via SSM Parameter Store
+#**********************
+
+data "aws_ssm_parameter" "shared_cloudfront_waf_arn" {
+  name = "/xomware/shared/cloudfront-waf-acl-arn"
 }
 
-# API Gateway WAF (REGIONAL scope)
-module "waf_api_gateway" {
-  source     = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
-  app_name   = "${var.app_name}-api-gateway"
-  scope      = "REGIONAL"
-  rate_limit = 2000
-  tags       = local.standard_tags
+data "aws_ssm_parameter" "shared_regional_waf_arn" {
+  name = "/xomware/shared/regional-waf-acl-arn"
 }
 
-# WAF association must be separate (can't use count with unknown values)
+# Associate shared regional WAF with API Gateway stage
 resource "aws_wafv2_web_acl_association" "api_gateway" {
-  web_acl_arn  = module.waf_api_gateway.web_acl_arn
+  web_acl_arn  = data.aws_ssm_parameter.shared_regional_waf_arn.value
   resource_arn = module.api.stage_arn
 }

--- a/terraform/web_hosting.tf
+++ b/terraform/web_hosting.tf
@@ -7,7 +7,7 @@ module "web" {
   tags        = local.standard_tags
   kms_key_arn = aws_kms_alias.web_app.target_key_arn
 
-  waf_acl_arn               = module.waf_cloudfront.web_acl_arn
+  waf_acl_arn               = data.aws_ssm_parameter.shared_cloudfront_waf_arn.value
   spa_error_path            = var.custom_error_response_page_path
   geo_restriction_locations = var.us_canada_only ? ["US", "CA"] : []
   enable_cache              = var.enable_cloudfront_cache


### PR DESCRIPTION
## Summary
- Remove local WAF module calls (`waf_cloudfront`, `waf_api_gateway`) that each provision dedicated WAF ACLs
- Consume shared WAF ACL ARNs from SSM Parameter Store, published by `xomware-infrastructure`
- Part of WAF consolidation effort to reduce total WAF ACLs from 8 to 2 across all apps, cutting WAF costs by ~75%

## Changes
- **`terraform/waf.tf`** — Replaced local WAF module calls with `aws_ssm_parameter` data sources reading shared ARNs from `/xomware/shared/cloudfront-waf-acl-arn` and `/xomware/shared/regional-waf-acl-arn`
- **`terraform/web_hosting.tf`** — Updated `waf_acl_arn` to reference the shared CloudFront WAF ARN from SSM

## Test plan
- [ ] Run `terraform plan` in dev environment and verify no unexpected resource destruction beyond the two WAF modules being removed
- [ ] Confirm SSM parameters exist in the target account (`/xomware/shared/cloudfront-waf-acl-arn`, `/xomware/shared/regional-waf-acl-arn`)
- [ ] Apply in dev, verify CloudFront distribution and API Gateway stage are associated with the shared WAF ACLs
- [ ] Confirm WAF rules still block test malicious requests against both CloudFront and API Gateway endpoints
- [ ] Validate CloudWatch WAF metrics still flow for xomper traffic under the shared ACLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)