### PR TITLE
fix: WAF migration phase 1

### DIFF
--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -16,3 +16,24 @@ resource "aws_wafv2_web_acl_association" "api_gateway" {
   web_acl_arn  = data.aws_ssm_parameter.shared_regional_waf_arn.value
   resource_arn = module.api.stage_arn
 }
+
+#**********************
+# Legacy WAF modules (kept temporarily for Phase 1)
+# These will be removed in Phase 2 after CloudFront
+# has been updated to use the shared WAF ARN
+#**********************
+
+module "waf_cloudfront" {
+  source   = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
+  app_name = "${var.app_name}-cloudfront"
+  scope    = "CLOUDFRONT"
+  tags     = local.standard_tags
+}
+
+module "waf_api_gateway" {
+  source     = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
+  app_name   = "${var.app_name}-api-gateway"
+  scope      = "REGIONAL"
+  rate_limit = 2000
+  tags       = local.standard_tags
+}


### PR DESCRIPTION
## Summary
- Re-adds legacy WAF modules (`waf_cloudfront` and `waf_api_gateway`) to prevent Terraform from destroying WAF ACLs while CloudFront still references them
- CloudFront and API Gateway now use shared WAF ARNs via SSM parameters (from previous PR)
- Legacy modules are kept alive but unreferenced — Phase 2 will remove them after the shared WAF is fully attached

## Test plan
- [ ] Run `terraform plan` and verify no WAF resources are being destroyed
- [ ] Confirm CloudFront distribution references the shared WAF ARN
- [ ] Confirm API Gateway stage is associated with the shared regional WAF

🤖 Generated with [Claude Code](https://claude.com/claude-code)