### PR TITLE
cost: remove legacy WAF modules (phase 2)

### DIFF
--- a/terraform/waf.tf
+++ b/terraform/waf.tf
@@ -16,24 +16,3 @@ resource "aws_wafv2_web_acl_association" "api_gateway" {
   web_acl_arn  = data.aws_ssm_parameter.shared_regional_waf_arn.value
   resource_arn = module.api.stage_arn
 }
-
-#**********************
-# Legacy WAF modules (kept temporarily for Phase 1)
-# These will be removed in Phase 2 after CloudFront
-# has been updated to use the shared WAF ARN
-#**********************
-
-module "waf_cloudfront" {
-  source   = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
-  app_name = "${var.app_name}-cloudfront"
-  scope    = "CLOUDFRONT"
-  tags     = local.standard_tags
-}
-
-module "waf_api_gateway" {
-  source     = "git::https://github.com/Xomware/waf.git?ref=v2.0.0"
-  app_name   = "${var.app_name}-api-gateway"
-  scope      = "REGIONAL"
-  rate_limit = 2000
-  tags       = local.standard_tags
-}


### PR DESCRIPTION
## Summary
- Removes legacy `waf_cloudfront` and `waf_api_gateway` modules that were kept temporarily during phase 1 of WAF consolidation
- Shared WAF ACLs (consumed via SSM) and the API Gateway association resource are retained

## Test plan
- [ ] Verify `terraform plan` shows only the two module removals (no unexpected changes)
- [ ] Confirm CloudFront distribution is already using the shared WAF ARN before apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)