### PR TITLE
fix: remove unsupported tags from SNS platform application

### DIFF
--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -10,5 +10,4 @@ resource "aws_sns_platform_application" "apns" {
   apple_platform_team_id   = var.apns_team_id
   apple_platform_bundle_id = var.apns_bundle_id
 
-  tags = merge(local.standard_tags, { "name" = "${var.app_name}-apns" })
 }


### PR DESCRIPTION
## Summary
- `aws_sns_platform_application` doesn't support `tags` argument — Terraform validate failed in CI

## Test plan
- [ ] Terraform validate passes