### PR TITLE
fix: add APNs secrets to Terraform workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -62,6 +62,9 @@ jobs:
           TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
           TF_VAR_supabase_url: ${{ secrets.SUPABASE_URL }}
           TF_VAR_supabase_anon_key: ${{ secrets.SUPABASE_ANON_KEY }}
+          TF_VAR_apns_team_id: ${{ secrets.APNS_TEAM_ID }}
+          TF_VAR_apns_key_id: ${{ secrets.APNS_KEY_ID }}
+          TF_VAR_apns_platform_credential: ${{ secrets.APNS_PLATFORM_CREDENTIAL }}
 
       - name: Post Plan to PR
         if: github.event_name == 'pull_request'
@@ -101,3 +104,6 @@ jobs:
           TF_VAR_api_secret_key: ${{ secrets.API_SECRET_KEY }}
           TF_VAR_supabase_url: ${{ secrets.SUPABASE_URL }}
           TF_VAR_supabase_anon_key: ${{ secrets.SUPABASE_ANON_KEY }}
+          TF_VAR_apns_team_id: ${{ secrets.APNS_TEAM_ID }}
+          TF_VAR_apns_key_id: ${{ secrets.APNS_KEY_ID }}
+          TF_VAR_apns_platform_credential: ${{ secrets.APNS_PLATFORM_CREDENTIAL }}

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -13,9 +13,9 @@ locals {
 
   # LAMBDAS
   lambda_variables = {
-    APP_NAME           = var.app_name
-    DYNAMODB_KMS_ALIAS = aws_kms_alias.xomper_dynamodb.name
-    AWS_ACCOUNT_ID     = data.aws_caller_identity.web_app_account.account_id
+    APP_NAME             = var.app_name
+    DYNAMODB_KMS_ALIAS   = aws_kms_alias.xomper_dynamodb.name
+    AWS_ACCOUNT_ID       = data.aws_caller_identity.web_app_account.account_id
     FROM_EMAIL           = var.from_email
     SNS_PLATFORM_APP_ARN = aws_sns_platform_application.apns.arn
     DEVICE_TOKENS_TABLE  = aws_dynamodb_table.device_tokens.name


### PR DESCRIPTION
## Summary
- Add `TF_VAR_apns_team_id`, `TF_VAR_apns_key_id`, `TF_VAR_apns_platform_credential` to both plan and apply steps
- GitHub secrets already set: `APNS_TEAM_ID`, `APNS_KEY_ID`, `APNS_PLATFORM_CREDENTIAL`

## Test plan
- [ ] Terraform plan succeeds with new variables
- [ ] Terraform apply creates SNS platform app + DynamoDB table + Lambda stubs