### PR TITLE
fix: add platform_principal to SNS APNs config

### DIFF
--- a/terraform/sns.tf
+++ b/terraform/sns.tf
@@ -7,6 +7,7 @@ resource "aws_sns_platform_application" "apns" {
   name                     = "${var.app_name}-apns"
   platform                 = "APNS"
   platform_credential      = var.apns_platform_credential
+  platform_principal       = var.apns_key_id
   apple_platform_team_id   = var.apns_team_id
   apple_platform_bundle_id = var.apns_bundle_id
 


### PR DESCRIPTION
## Summary
- APNs token-based auth requires `platform_principal` (Key ID) alongside `platform_credential` (.p8 key)
- Without it, SNS CreatePlatformApplication fails with "Missing required attributes"

## Test plan
- [ ] Terraform apply creates SNS platform application successfully