### PR TITLE
feat: xomper-worldcup-snapshots DynamoDB table

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -261,6 +261,39 @@ resource "aws_dynamodb_table" "league_champions" {
   tags = merge(local.standard_tags, { "name" = "${var.app_name}-league-champions" })
 }
 
+# --- World Cup Snapshots (per-week clinch state) ---
+# Drives `notif_worldcup_movement` — the lambda diffs the current
+# week's computed clinch status against the prior snapshot to decide
+# which managers get a transition push. PK = league_id#season,
+# SK = week, item value is the per-team status map.
+resource "aws_dynamodb_table" "worldcup_snapshots" {
+  name         = "${var.app_name}-worldcup-snapshots"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "league_id_season"
+  range_key    = "week"
+
+  attribute {
+    name = "league_id_season"
+    type = "S"
+  }
+
+  attribute {
+    name = "week"
+    type = "N"
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = local.dynamodb_kms_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = merge(local.standard_tags, { "name" = "${var.app_name}-worldcup-snapshots" })
+}
+
 # --- Device Tokens (Push Notifications) ---
 resource "aws_dynamodb_table" "device_tokens" {
   name         = "${var.app_name}-device-tokens"


### PR DESCRIPTION
## Summary
Adds the \`xomper-worldcup-snapshots\` DynamoDB table that drives \`notif_worldcup_movement\`. Pairs with xomper-back-end PR #55.

- **PK**: \`league_id_season\` (S, e.g. \`1234#2026\`)
- **SK**: \`week\` (N)
- **Value**: \`status_map\` (S, JSON-encoded user_id → clinch state)
- KMS-encrypted, PITR enabled, PAY_PER_REQUEST

Lambda IAM role already covers this via the wildcard ARN pattern (\`\${var.app_name}*\`) — no IAM change needed.

🤖 Closes follow-up for #49