### PR TITLE
feat: notification log table + admin API routes

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -21,6 +21,15 @@ locals {
       invoke_arn  = aws_lambda_function.api[l.name].invoke_arn
     } if startswith(l.name, "device-")
   ]
+
+  admin_endpoints = [
+    for l in local.api_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.api[l.name].invoke_arn
+    } if startswith(l.name, "admin-")
+  ]
 }
 
 module "api" {
@@ -47,6 +56,10 @@ module "api" {
     device = {
       path_prefix = "device"
       endpoints   = local.device_endpoints
+    }
+    admin = {
+      path_prefix = "admin"
+      endpoints   = local.admin_endpoints
     }
     # New API services (profiles, rules, etc.) will be added during Supabase migration
   }

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -261,6 +261,41 @@ resource "aws_dynamodb_table" "league_champions" {
   tags = merge(local.standard_tags, { "name" = "${var.app_name}-league-champions" })
 }
 
+# --- Notification Activity Log (admin portal) ---
+# Drives the iOS Admin portal's activity feed. Every push +
+# email send writes a row from inside ses_helper.send_email and
+# sns_helper.send_push_to_users. PK = day (S, "YYYY-MM-DD"),
+# SK = id (S, "{epoch_ms:013d}#{uuid_short}") — sorts newest-last
+# inside the partition so reads with ScanIndexForward=false stream
+# newest-first.
+resource "aws_dynamodb_table" "notification_log" {
+  name         = "${var.app_name}-notification-log"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "day"
+  range_key    = "id"
+
+  attribute {
+    name = "day"
+    type = "S"
+  }
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = local.dynamodb_kms_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = merge(local.standard_tags, { "name" = "${var.app_name}-notification-log" })
+}
+
 # --- World Cup Snapshots (per-week clinch state) ---
 # Drives `notif_worldcup_movement` — the lambda diffs the current
 # week's computed clinch status against the prior snapshot to decide

--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -54,6 +54,13 @@ locals {
     # Device Registration (Push Notifications)
     { name = "device-register", description = "Register device for push notifications", path_part = "register", http_method = "POST" },
     { name = "device-unregister", description = "Unregister device from push notifications", path_part = "unregister", http_method = "POST" },
+
+    # Admin Portal (notification activity log + test send)
+    # Backend dirs:
+    #   lambdas/api_admin_list_notifications/  → xomper-api-admin-list-notifications
+    #   lambdas/api_admin_test_send/           → xomper-api-admin-test-send
+    { name = "admin-list-notifications", description = "Admin: list recent push + email activity", path_part = "notifications", http_method = "GET" },
+    { name = "admin-test-send", description = "Admin: fire a sample push + email back to caller", path_part = "test-send", http_method = "POST" },
   ]
 }
 


### PR DESCRIPTION
Pairs with xomper-back-end PR #56 (admin portal). Adds the activity-log table + 2 admin API endpoints under `/admin/notifications` (GET) and `/admin/test-send` (POST). IAM already covers via wildcard.