### PR TITLE
feat(ai-review F0): infra — Dynamo table + SSM key + API routes + cost alarm

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -66,6 +66,7 @@ jobs:
           TF_VAR_apns_team_id: ${{ secrets.APNS_TEAM_ID }}
           TF_VAR_apns_key_id: ${{ secrets.APNS_KEY_ID }}
           TF_VAR_apns_platform_credential: ${{ secrets.APNS_PLATFORM_CREDENTIAL }}
+          TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
       - name: Post Plan to PR
         if: github.event_name == 'pull_request'
@@ -109,3 +110,4 @@ jobs:
           TF_VAR_apns_team_id: ${{ secrets.APNS_TEAM_ID }}
           TF_VAR_apns_key_id: ${{ secrets.APNS_KEY_ID }}
           TF_VAR_apns_platform_credential: ${{ secrets.APNS_PLATFORM_CREDENTIAL }}
+          TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -30,6 +30,15 @@ locals {
       invoke_arn  = aws_lambda_function.api[l.name].invoke_arn
     } if startswith(l.name, "admin-")
   ]
+
+  ai_reports_endpoints = [
+    for l in local.api_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.api[l.name].invoke_arn
+    } if startswith(l.name, "ai-reports-")
+  ]
 }
 
 module "api" {
@@ -60,6 +69,10 @@ module "api" {
     admin = {
       path_prefix = "admin"
       endpoints   = local.admin_endpoints
+    }
+    ai_reports = {
+      path_prefix = "ai-reports"
+      endpoints   = local.ai_reports_endpoints
     }
     # New API services (profiles, rules, etc.) will be added during Supabase migration
   }

--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -1,0 +1,87 @@
+###############################################################################
+# CloudWatch Alarms
+#
+# AI Review (F0) — invocation-count guard
+# -----------------------------------------------------------------------------
+# The original brainstorm asked for a "$5/month cost alarm" against the three
+# forthcoming AI Review lambdas (notif_ai_review_post_draft / _preseason /
+# _weekly). AWS's native billing metrics (AWS/Billing → EstimatedCharges)
+# require billing-data export to be enabled in the payer account AND the
+# metric is only emitted in us-east-1 — they also do NOT slice by Lambda
+# function name or resource tag, so a true "$5/month on these three lambdas
+# only" alarm isn't expressible without a custom metric pipeline (Cost
+# Explorer API → custom CW metric via a scheduled lambda — overkill for F0).
+#
+# We instead use an **invocation-count proxy**: at Claude Haiku pricing
+# (~$0.001/call typical for our token budget), 50 invocations/day across
+# the three lambdas is the worst-case ceiling that keeps us under ~$5/mo.
+# This catches a runaway loop or schedule-storm — the realistic failure
+# mode — without depending on Cost Explorer wiring.
+#
+# Aggregation: SUM of `AWS/Lambda` `Invocations` across the three function
+# names via a metric_query. Period = 1 day, threshold = 50.
+#
+# NOTE: These three function names are referenced by the F1/F2/F3 plans —
+# they don't exist yet at F0 merge. The alarm will sit in INSUFFICIENT_DATA
+# state until F1 ships its first scheduled lambda. That's expected.
+###############################################################################
+
+resource "aws_cloudwatch_metric_alarm" "ai_review_invocations_guard" {
+  alarm_name          = "${var.app_name}-ai-review-invocations-guard"
+  alarm_description   = "AI Review cost proxy: alarms when the three notif_ai_review_* lambdas combined fire more than 50 times in a day. Sits in INSUFFICIENT_DATA until F1 deploys the first scheduled lambda."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  threshold           = 50
+  treat_missing_data  = "notBreaching"
+
+  metric_query {
+    id          = "total"
+    expression  = "SUM(METRICS())"
+    label       = "AI Review total daily invocations"
+    return_data = true
+  }
+
+  metric_query {
+    id = "post_draft"
+    metric {
+      metric_name = "Invocations"
+      namespace   = "AWS/Lambda"
+      period      = 86400
+      stat        = "Sum"
+      dimensions = {
+        FunctionName = "${var.app_name}-notif-ai-review-post-draft"
+      }
+    }
+  }
+
+  metric_query {
+    id = "preseason"
+    metric {
+      metric_name = "Invocations"
+      namespace   = "AWS/Lambda"
+      period      = 86400
+      stat        = "Sum"
+      dimensions = {
+        FunctionName = "${var.app_name}-notif-ai-review-preseason"
+      }
+    }
+  }
+
+  metric_query {
+    id = "weekly"
+    metric {
+      metric_name = "Invocations"
+      namespace   = "AWS/Lambda"
+      period      = 86400
+      stat        = "Sum"
+      dimensions = {
+        FunctionName = "${var.app_name}-notif-ai-review-weekly"
+      }
+    }
+  }
+
+  tags = merge(local.standard_tags, {
+    "name"    = "${var.app_name}-ai-review-invocations-guard"
+    "feature" = "ai-review"
+  })
+}

--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -329,6 +329,55 @@ resource "aws_dynamodb_table" "worldcup_snapshots" {
   tags = merge(local.standard_tags, { "name" = "${var.app_name}-worldcup-snapshots" })
 }
 
+# --- AI Reports (AI Review F0) ---
+# Stores Claude-generated league reports (post-draft, preseason, weekly).
+# PK = "LEAGUE#<league_id>" (S), SK = "REPORT#<report_type>#<period>" (S).
+# GSI `created-at-index` reuses PK and ranges on `created_at` (ISO 8601)
+# for newest-first archive queries via the /ai-reports/list endpoint.
+# Body lives in `body_markdown` (S); metadata Map carries model, prompt
+# version, token usage, etc. No CreateTable/DeleteTable IAM — runtime
+# lambda role only reads + writes via the existing `${var.app_name}*`
+# wildcard in `iam_lambdas.tf:DynamoDBRuntime`.
+resource "aws_dynamodb_table" "ai_reports" {
+  name         = "${var.app_name}-ai-reports"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+  range_key    = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  attribute {
+    name = "created_at"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "created-at-index"
+    hash_key        = "pk"
+    range_key       = "created_at"
+    projection_type = "ALL"
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = local.dynamodb_kms_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = merge(local.standard_tags, { "name" = "${var.app_name}-ai-reports" })
+}
+
 # --- Device Tokens (Push Notifications) ---
 resource "aws_dynamodb_table" "device_tokens" {
   name         = "${var.app_name}-device-tokens"

--- a/terraform/iam_lambdas.tf
+++ b/terraform/iam_lambdas.tf
@@ -149,6 +149,9 @@ data "aws_iam_policy_document" "lambda_role_policy" {
       "ssm:GetParameterHistory",
       "ssm:GetParametersByPath"
     ]
+    # NOTE: AI Review F0 — covered by the /${var.app_name}/* wildcard.
+    # The `/xomper/api/ANTHROPIC_API_KEY` SecureString sits under this prefix
+    # and is read at runtime by `claude_helper.py` via ssm:GetParameter.
     resources = ["arn:aws:ssm:${var.aws_region}:${data.aws_caller_identity.web_app_account.account_id}:parameter/${var.app_name}/*"]
   }
 
@@ -255,6 +258,9 @@ data "aws_iam_policy_document" "lambda_role_policy" {
   }
 
   # DynamoDB runtime access -- no CreateTable/DeleteTable (those are Terraform's job)
+  # NOTE: AI Review F0 — `xomper-ai-reports` + its `created-at-index` GSI are
+  # covered by the `${var.app_name}*` table wildcard and the `*/index/*`
+  # wildcard below. No additional statement needed.
   statement {
     sid    = "DynamoDBRuntime"
     effect = "Allow"

--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -61,6 +61,16 @@ locals {
     #   lambdas/api_admin_test_send/           → xomper-api-admin-test-send
     { name = "admin-list-notifications", description = "Admin: list recent push + email activity", path_part = "notifications", http_method = "GET" },
     { name = "admin-test-send", description = "Admin: fire a sample push + email back to caller", path_part = "test-send", http_method = "POST" },
+
+    # AI Review (F0) — paginated archive + latest-by-type reads.
+    # Routes land at /ai-reports/latest and /ai-reports/list under the new
+    # `ai-reports` API GW service block (see api_gateway.tf). Query params
+    # are documented in the backend handlers; iOS hits both via XomperAPIClient.
+    # Backend dirs:
+    #   lambdas/api_ai_reports_latest/  → xomper-api-ai-reports-latest
+    #   lambdas/api_ai_reports_list/    → xomper-api-ai-reports-list
+    { name = "ai-reports-latest", description = "AI Review: latest report by type (query ?type=postDraft|preseason|weekly)", path_part = "latest", http_method = "GET" },
+    { name = "ai-reports-list", description = "AI Review: paginated archive (query ?type=&limit=&cursor=)", path_part = "list", http_method = "GET" },
   ]
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -78,6 +78,18 @@ output "dynamodb_table_arns" {
   }
 }
 
+# AI Review (F0) — direct table name/arn outputs for downstream reference
+# (backend deploy scripts, future cross-stack lookups, manual debugging).
+output "ai_reports_table_name" {
+  description = "DynamoDB table name for AI Review reports"
+  value       = aws_dynamodb_table.ai_reports.name
+}
+
+output "ai_reports_table_arn" {
+  description = "DynamoDB table ARN for AI Review reports"
+  value       = aws_dynamodb_table.ai_reports.arn
+}
+
 # Route53
 output "route53_zone_id" {
   description = "Route53 hosted zone ID"

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -97,19 +97,18 @@ resource "aws_ssm_parameter" "api_supabase_service_key" {
 }
 
 # ANTHROPIC (AI Review F0)
-# Terraform creates this SecureString with a placeholder value. The real key
-# is set manually via the AWS console post-apply. `ignore_changes = [value]`
-# means future plans will NOT revert the manually-set value back to the
-# placeholder. The lambda code fetches via ssm:GetParameter at runtime and
-# caches at the module level — a console update is picked up on the next
-# lambda cold start with no redeploy required.
+# Value sourced from var.anthropic_api_key, which CI feeds from the
+# ANTHROPIC_API_KEY GitHub Secret on the xomper-infrastructure repo (see the
+# TF_VAR_anthropic_api_key entry in .github/workflows/terraform.yml). Rotate
+# by updating the GitHub Secret and triggering a new apply — never edit the
+# parameter value via the AWS console or CLI.
 resource "aws_ssm_parameter" "anthropic_api_key" {
   name        = "/${var.app_name}/api/ANTHROPIC_API_KEY"
-  description = "Anthropic API key for AI Review (F0). Value managed manually via AWS console — Terraform only provisions the parameter."
+  description = "Anthropic API key for AI Review (F0). Managed by Terraform; value sourced from ANTHROPIC_API_KEY GitHub Secret."
   type        = "SecureString"
   value       = var.anthropic_api_key
 
   lifecycle {
-    ignore_changes = [tags, tags_all, value]
+    ignore_changes = [tags, tags_all]
   }
 }

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -95,3 +95,21 @@ resource "aws_ssm_parameter" "api_supabase_service_key" {
     ignore_changes = [tags, tags_all]
   }
 }
+
+# ANTHROPIC (AI Review F0)
+# Terraform creates this SecureString with a placeholder value. The real key
+# is set manually via the AWS console post-apply. `ignore_changes = [value]`
+# means future plans will NOT revert the manually-set value back to the
+# placeholder. The lambda code fetches via ssm:GetParameter at runtime and
+# caches at the module level — a console update is picked up on the next
+# lambda cold start with no redeploy required.
+resource "aws_ssm_parameter" "anthropic_api_key" {
+  name        = "/${var.app_name}/api/ANTHROPIC_API_KEY"
+  description = "Anthropic API key for AI Review (F0). Value managed manually via AWS console — Terraform only provisions the parameter."
+  type        = "SecureString"
+  value       = var.anthropic_api_key
+
+  lifecycle {
+    ignore_changes = [tags, tags_all, value]
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -125,6 +125,19 @@ variable "supabase_service_key" {
   sensitive   = true
 }
 
+# Anthropic (AI Review F0)
+# NOTE: The real key value is set manually via the AWS console after `terraform
+# apply`. The SSM resource for this var has `lifecycle.ignore_changes = [value]`
+# so subsequent plans do not revert the console-edited value back to the
+# placeholder. Default = placeholder so `terraform plan/apply` does not require
+# an interactive prompt or a tfvars entry on bootstrap.
+variable "anthropic_api_key" {
+  description = "Anthropic API key for the AI Review feature. Placeholder by default — set the real value in AWS SSM Parameter Store via the console after apply."
+  type        = string
+  sensitive   = true
+  default     = "PLACEHOLDER_SET_VIA_CONSOLE"
+}
+
 # Push Notifications (APNs)
 variable "apns_team_id" {
   description = "Apple Developer Team ID for APNs"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -125,17 +125,10 @@ variable "supabase_service_key" {
   sensitive   = true
 }
 
-# Anthropic (AI Review F0)
-# NOTE: The real key value is set manually via the AWS console after `terraform
-# apply`. The SSM resource for this var has `lifecycle.ignore_changes = [value]`
-# so subsequent plans do not revert the console-edited value back to the
-# placeholder. Default = placeholder so `terraform plan/apply` does not require
-# an interactive prompt or a tfvars entry on bootstrap.
 variable "anthropic_api_key" {
-  description = "Anthropic API key for the AI Review feature. Placeholder by default — set the real value in AWS SSM Parameter Store via the console after apply."
+  description = "Anthropic API key for the AI Review feature. Sourced from the ANTHROPIC_API_KEY GitHub Secret on the xomper-infrastructure repo via TF_VAR_anthropic_api_key in the terraform.yml workflow."
   type        = string
   sensitive   = true
-  default     = "PLACEHOLDER_SET_VIA_CONSOLE"
 }
 
 # Push Notifications (APNs)


### PR DESCRIPTION
## Summary

Phase 0 infra for the **AI Review** epic (issue [Xomware/xomper-ios#79](https://github.com/Xomware/xomper-ios/issues/79)). Provisions shared resources F1/F2/F3 will consume — no lambda code or iOS code in this PR.

**Resources added:**
- `aws_dynamodb_table.ai_reports` — `xomper-ai-reports`. PK `pk` / SK `sk`, GSI `created-at-index` on `(pk, created_at)`. PAY_PER_REQUEST, KMS, PITR.
- `aws_ssm_parameter.anthropic_api_key` — `/xomper/api/ANTHROPIC_API_KEY` (SecureString). **Value sourced via Terraform** from `var.anthropic_api_key`, which CI feeds from the `ANTHROPIC_API_KEY` GitHub Secret. No `ignore_changes` on `value`.
- 2 API GW routes: `GET /ai-reports/latest` + `GET /ai-reports/list`. Lambda stubs created here; backend repo deploys real code.
- `aws_cloudwatch_metric_alarm.ai_review_invocations_guard` — fires when sum of invocations across `notif_ai_review_{postdraft,preseason,weekly}` > 50/day. Invocation-count proxy (AWS doesn't expose per-resource billing dims natively).
- Outputs: `ai_reports_table_name`, `ai_reports_table_arn`.

## :rotating_light: Pre-merge requirement

Before merging, add the Anthropic API key to GitHub Secrets on this repo:

1. Go to [Settings → Secrets and variables → Actions](https://github.com/Xomware/xomper-infrastructure/settings/secrets/actions)
2. Click **New repository secret**
3. Name: `ANTHROPIC_API_KEY`
4. Value: your Anthropic API key (starts with `sk-ant-`)

`terraform apply` will fail fast on merge if this Secret is missing because the variable has no default. **This is intentional** — Terraform is the single source of truth for the SSM value; no CLI/console updates.

**To rotate the key later:** update the GitHub Secret + push to master (or `workflow_dispatch` the Terraform workflow) → next apply propagates the new value to SSM → lambdas pick it up on next cold start (claude_helper reads SSM lazily and caches at module level).

## Cost alarm note

Plan called for $5/month dollar-based alarm; AWS doesn't expose per-resource billing dims natively, so this uses an invocation-count guard (50/day across the 3 AI lambdas → alarm). At Haiku rates this caps spend ~$5/mo. Documented in `cloudwatch.tf` block comment.

## Plan reference

- Epic: [`docs/features/ai-review/EPIC_PLAN.md`](https://github.com/Xomware/xomper-ios/blob/main/docs/features/ai-review/EPIC_PLAN.md)
- F0 plan: [`docs/features/ai-review/f0-shared-infra/PLAN.md`](https://github.com/Xomware/xomper-ios/blob/main/docs/features/ai-review/f0-shared-infra/PLAN.md) (see Appendix B for the Terraform-only SSM flow)

## Test plan / acceptance

- [ ] `ANTHROPIC_API_KEY` GitHub Secret added to xomper-infrastructure repo
- [ ] CI `terraform plan` succeeds with the new Secret present (Plan step pulls TF_VAR_anthropic_api_key from the secret)
- [ ] After merge, CI runs `terraform apply -auto-approve` — all resources land, SSM SecureString holds the real value
- [ ] Backend PR can read both the Dynamo table and the SSM key with the existing wildcard IAM coverage