### PR TITLE
feat(ai-review F1): infra — admin trigger API route for post-draft AI review

### DIFF
--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -57,10 +57,20 @@ locals {
 
     # Admin Portal (notification activity log + test send)
     # Backend dirs:
-    #   lambdas/api_admin_list_notifications/  → xomper-api-admin-list-notifications
-    #   lambdas/api_admin_test_send/           → xomper-api-admin-test-send
+    #   lambdas/api_admin_list_notifications/             → xomper-api-admin-list-notifications
+    #   lambdas/api_admin_test_send/                      → xomper-api-admin-test-send
+    #   lambdas/api_admin_ai_review_postdraft_trigger/    → xomper-api-admin-ai-review-postdraft-trigger
     { name = "admin-list-notifications", description = "Admin: list recent push + email activity", path_part = "notifications", http_method = "GET" },
     { name = "admin-test-send", description = "Admin: fire a sample push + email back to caller", path_part = "test-send", http_method = "POST" },
+
+    # AI Review (F1) — admin-triggered post-draft report generator.
+    # The api-gateway-service v2.2.0 module supports only `path_prefix` + `path_part`
+    # (two-segment paths). Per the F1 plan's Step 3 fallback, the route is flattened
+    # under the existing `admin` service block as `/admin/ai-review-postdraft-trigger`
+    # instead of the deeper `/admin/ai-review/post-draft/trigger`. JWT + admin gate
+    # are enforced by the shared authorizer (lambdas/authorizer/) and the backend
+    # handler (mirrors api_admin_test_send admin check).
+    { name = "admin-ai-review-postdraft-trigger", description = "Admin: trigger post-draft AI review generation (body: dry_run, force)", path_part = "ai-review-postdraft-trigger", http_method = "POST" },
 
     # AI Review (F0) — paginated archive + latest-by-type reads.
     # Routes land at /ai-reports/latest and /ai-reports/list under the new


### PR DESCRIPTION
## Summary

Adds the single new admin-authenticated API route + lambda stub that F1 (Post-Draft AI Review) needs.

- New `api_lambdas` entry: `admin-ai-review-postdraft-trigger` (POST), wired into the existing `admin` service block in `api_gateway.tf` (automatic via the `startswith(l.name, \"admin-\")` filter).
- Route: `POST /admin/ai-review-postdraft-trigger` (flattened — see note below).
- Backend dir mapping: `lambdas/api_admin_ai_review_postdraft_trigger/` (backend PR forthcoming will replace the stub with real code).
- Auth: JWT via the existing shared authorizer + admin gate enforced inside the backend handler (mirrors `api_admin_test_send`).
- IAM: **no widening** — the existing `${app_name}*` Dynamo wildcard, `/${app_name}/*` SSM wildcard, `ses:SendEmail`, and `sns:Publish` statements on `xomper-lambda-exec` already cover everything this lambda needs at runtime.
- Tags: inherits `local.standard_tags` (app_name, environment, owner, source).

### Why the path is flattened

The F1 plan called for `/admin/ai-review/post-draft/trigger` (four segments). The shared `api-gateway-service` module v2.2.0 supports only `path_prefix` + `path_part` (two segments). Per the plan's **Step 3** fallback, the route is flattened to `/admin/ai-review-postdraft-trigger` instead of forking the module for one route. Backend handler + iOS `XomperAPIClient` will use this URL.

### Plan summary

```
Plan: 10 to add, 15 to change, 1 to destroy.
```

- **10 to add**: all scoped to the new route (lambda function, API GW resource, POST method, integration, CORS OPTIONS method/method_response/integration/integration_response, lambda permission, plus the module-internal endpoint key).
- **15 to change**: pre-existing drift unrelated to this PR (ACM cert in-place updates, SSM params re-encrypted by Terraform on every plan because of the lambda role policy re-evaluation, SNS app, API GW domain + stage in-place tag refresh). The SSM param diffs locally are spurious because plan was run with placeholder vars; CI will plan with real GitHub Secret values.
- **1 to destroy**: `module.api.aws_api_gateway_deployment.deploy` is replaced — expected behavior any time the endpoint list changes.

### Backend / iOS follow-up

- Backend PR (forthcoming) deploys the real handler at `lambdas/api_admin_ai_review_postdraft_trigger/` + the orchestrator at `lambdas/notif_ai_review_postdraft/`.
- iOS PR (forthcoming) adds the trigger card to `AdminView` + the `XomperAPIClient.triggerPostDraftAIReview(dryRun:force:)` method.

### Links

- F1 plan: `xomper-ios/docs/features/ai-review/f1-post-draft/PLAN.md` (status: Ready)
- Tracking issue: Xomware/xomper-ios#79
- Depends on F0 infra (#103, already merged): Dynamo table, SSM API key, cost alarm, `ai-reports-latest` + `ai-reports-list` routes.

## Test plan

- [ ] CI `terraform plan` job is green and shows the same `10 add / 15 change / 1 destroy` shape.
- [ ] CI `terraform apply` on merge to `master` succeeds.
- [ ] After apply, `curl -X POST https://api.xomper.xomware.com/admin/ai-review-postdraft-trigger` with no `Authorization` header → **401** (authorizer rejects).
- [ ] Same call with a non-admin JWT → **403** (handler admin gate rejects — proves once backend deploys real code).
- [ ] Same call with an admin JWT → **200 / 202** once the backend PR is deployed and the draft is complete (will return 412 before draft finishes, per plan's defensive check).