### PR TITLE
feat(ai-review F2): infra — admin trigger API route for preseason AI review

### DIFF
--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -72,6 +72,14 @@ locals {
     # handler (mirrors api_admin_test_send admin check).
     { name = "admin-ai-review-postdraft-trigger", description = "Admin: trigger post-draft AI review generation (body: dry_run, force)", path_part = "ai-review-postdraft-trigger", http_method = "POST" },
 
+    # AI Review (F2) — admin-triggered preseason report generator.
+    # Same wiring + auth model as F1's post-draft trigger above. Path is flattened
+    # under `/admin/*` for the same api-gateway-service v2.2.0 reason. Backend dir:
+    #   lambdas/api_admin_ai_review_preseason_trigger/  → xomper-api-admin-ai-review-preseason-trigger
+    # IAM coverage: existing wildcards on xomper-lambda-exec (Dynamo R/W, SSM read,
+    # SES, SNS) already cover the new lambda — no IAM changes needed.
+    { name = "admin-ai-review-preseason-trigger", description = "AI Review: admin-triggered preseason report (dry-run first, then broadcast)", path_part = "ai-review-preseason-trigger", http_method = "POST" },
+
     # AI Review (F0) — paginated archive + latest-by-type reads.
     # Routes land at /ai-reports/latest and /ai-reports/list under the new
     # `ai-reports` API GW service block (see api_gateway.tf). Query params


### PR DESCRIPTION
## Summary

Adds the single new admin-authenticated API route + lambda stub that F2 (Preseason AI Review) needs. This mirrors the F1 post-draft trigger infra PR ([#104](https://github.com/Xomware/xomper-infrastructure/pull/104)) verbatim — same wiring, auth model, and IAM coverage.

- New `api_lambdas` entry: `admin-ai-review-preseason-trigger` (POST), wired into the existing `admin` service block in `api_gateway.tf` (automatic via the `startswith(l.name, "admin-")` filter).
- Route: `POST /admin/ai-review-preseason-trigger` (flattened — see note below).
- Backend dir mapping: `lambdas/api_admin_ai_review_preseason_trigger/` (backend PR forthcoming will replace the stub with real code).
- Auth: JWT via the existing shared authorizer + admin gate enforced inside the backend handler (mirrors `api_admin_ai_review_postdraft_trigger`).
- IAM: **no widening** — the existing `${app_name}*` Dynamo wildcard, `/${app_name}/*` SSM wildcard, `ses:SendEmail`, and `sns:Publish` statements on `xomper-lambda-exec` already cover everything this lambda needs at runtime.
- Tags: inherits `local.standard_tags` (app_name, environment, owner, source).

### Why the path is flattened

Same constraint as F1: the shared `api-gateway-service` module v2.2.0 supports only `path_prefix` + `path_part` (two segments). Per the F2 plan, the route lives at `/admin/ai-review-preseason-trigger` (parallel structure to F1's `/admin/ai-review-postdraft-trigger`) instead of a deeper nested path.

### Plan summary

```
Plan: 10 to add, 15 to change, 1 to destroy.
```

- **10 to add**: all scoped to the new route (lambda function, API GW resource, POST method, integration, CORS OPTIONS method/method_response/integration/integration_response, lambda permission, plus the module-internal endpoint key).
- **15 to change**: pre-existing drift unrelated to this PR (ACM cert in-place updates, SSM params re-encrypted by Terraform on every plan because of the lambda role policy re-evaluation, SNS app, API GW domain + stage in-place tag refresh). Same shape as PR #104.
- **1 to destroy**: `module.api.aws_api_gateway_deployment.deploy` is replaced — expected behavior any time the endpoint list changes.

### Backend / iOS follow-up

- Backend PR (forthcoming) deploys the real handler at `lambdas/api_admin_ai_review_preseason_trigger/` + the orchestrator/prompts modules.
- iOS PR (forthcoming) adds the second trigger card to `AdminView` (directly below the existing Post-Draft card) + `XomperAPIClient.triggerPreseasonAIReview(dryRun:force:)`.

### Links

- F2 plan: `xomper-ios/docs/features/ai-review/f2-preseason/PLAN.md` (status: Ready)
- Tracking issue: Xomware/xomper-ios#79
- F1 infra PR (mirrored): #104 (merged)
- Depends on F0 infra (#103, already merged) + F1 infra (#104, already merged)

## Test plan

- [ ] CI `terraform plan` job is green and shows the same `10 add / 15 change / 1 destroy` shape.
- [ ] CI `terraform apply` on merge to `master` succeeds.
- [ ] After apply, `curl -X POST https://api.xomper.xomware.com/admin/ai-review-preseason-trigger` with no `Authorization` header → **401** (authorizer rejects).
- [ ] Same call with a non-admin JWT → **403** (handler admin gate rejects — proves once backend deploys real code).
- [ ] Same call with an admin JWT → **200** once the backend PR is deployed.