### PR TITLE
feat(ai-review F3): infra — ai-memories Dynamo + weekly cron + admin trigger

### DIFF
--- a/terraform/dynamodb.tf
+++ b/terraform/dynamodb.tf
@@ -378,6 +378,49 @@ resource "aws_dynamodb_table" "ai_reports" {
   tags = merge(local.standard_tags, { "name" = "${var.app_name}-ai-reports" })
 }
 
+# --- AI Memories (AI Review F3) ---
+# Stores Claude-generated season memories appended every Tuesday by the
+# weekly recap orchestrator. Lookback (default 6 newest) is injected into
+# the next week's user prompt so the recap carries continuity.
+# PK = "LEAGUE#<league_id>#SEASON#<year>" (S) — season-scoped so a fresh
+# season (e.g. 2027) starts empty without manual purge.
+# SK = "MEMORY#<week:02d>#<memory_id>" (S) where memory_id is a uuid4 hex.
+# Additional attributes (memory_id, season, week, manager_user_id, text,
+# sentiment, created_at) are item attributes only — not part of the key
+# schema, so they don't need declaring on the resource.
+# No GSI in v1 — the only access pattern is "Query PK + SK begins_with
+# MEMORY# with ScanIndexForward=false, Limit=N" which works on the base
+# table. Add a GSI in v1.1 only if a per-manager query becomes a thing.
+# IAM coverage: existing `${var.app_name}*` wildcard in iam_lambdas.tf:
+# DynamoDBRuntime covers R/W on this table.
+resource "aws_dynamodb_table" "ai_memories" {
+  name         = "${var.app_name}-ai-memories"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "pk"
+  range_key    = "sk"
+
+  attribute {
+    name = "pk"
+    type = "S"
+  }
+
+  attribute {
+    name = "sk"
+    type = "S"
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = local.dynamodb_kms_key_arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  tags = merge(local.standard_tags, { "name" = "${var.app_name}-ai-memories" })
+}
+
 # --- Device Tokens (Push Notifications) ---
 resource "aws_dynamodb_table" "device_tokens" {
   name         = "${var.app_name}-device-tokens"

--- a/terraform/iam_lambdas.tf
+++ b/terraform/iam_lambdas.tf
@@ -261,6 +261,9 @@ data "aws_iam_policy_document" "lambda_role_policy" {
   # NOTE: AI Review F0 — `xomper-ai-reports` + its `created-at-index` GSI are
   # covered by the `${var.app_name}*` table wildcard and the `*/index/*`
   # wildcard below. No additional statement needed.
+  # NOTE: AI Review F3 — `xomper-ai-memories` (no GSI) is covered by the same
+  # `${var.app_name}*` table wildcard. R/W from notif_ai_review_weekly and
+  # api_admin_ai_review_weekly_trigger lambdas flows through this statement.
   statement {
     sid    = "DynamoDBRuntime"
     effect = "Allow"

--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -80,6 +80,14 @@ locals {
     # SES, SNS) already cover the new lambda — no IAM changes needed.
     { name = "admin-ai-review-preseason-trigger", description = "AI Review: admin-triggered preseason report (dry-run first, then broadcast)", path_part = "ai-review-preseason-trigger", http_method = "POST" },
 
+    # AI Review (F3) — admin-triggered weekly recap (cron retries + dry-run calibration).
+    # Same wiring + auth model as F1/F2 above. Flattened under `/admin/*` for the
+    # same api-gateway-service v2.2.0 reason. Backend dir:
+    #   lambdas/api_admin_ai_review_weekly_trigger/  → xomper-api-admin-ai-review-weekly-trigger
+    # IAM coverage: existing wildcards on xomper-lambda-exec already cover the new
+    # lambda + xomper-ai-memories R/W — no IAM changes needed.
+    { name = "admin-ai-review-weekly-trigger", description = "AI Review: weekly recap admin trigger (cron retries + dry-run calibration)", path_part = "ai-review-weekly-trigger", http_method = "POST" },
+
     # AI Review (F0) — paginated archive + latest-by-type reads.
     # Routes land at /ai-reports/latest and /ai-reports/list under the new
     # `ai-reports` API GW service block (see api_gateway.tf). Query params

--- a/terraform/lambdas_scheduled.tf
+++ b/terraform/lambdas_scheduled.tf
@@ -48,6 +48,22 @@ locals {
       cron_expression   = "cron(0 10 ? * TUE *)" # Tue 10:00 ET, after recap
       schedule_timezone = "America/New_York"
     },
+    # AI Review (F3) — weekly recap cron.
+    # Fires Tue 14:00 ET — far enough past Monday Night Football (~23:30 ET
+    # Mon) for Sleeper's nfl_state.week to have incremented, and 5h past
+    # `notif-weekly-recap` (09:00 ET) so the two products land separately
+    # in inboxes. ET is interpreted directly by EventBridge via
+    # schedule_timezone, so no DST math needed (same convention as the
+    # other five entries above).
+    # IAM coverage: existing wildcards in iam_lambdas.tf cover the new
+    # function name + Dynamo R/W on xomper-ai-memories / xomper-ai-reports.
+    {
+      name              = "notif-ai-review-weekly"
+      handler_dir       = "notif_ai_review_weekly"
+      description       = "Tuesday afternoon: AI-generated weekly league newsletter (Claude Haiku)"
+      cron_expression   = "cron(0 14 ? * TUE *)" # Tue 14:00 ET, post-MNF
+      schedule_timezone = "America/New_York"
+    },
   ]
 
   # Same env block as locals.lambda_variables but kept separate so we can

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -90,6 +90,17 @@ output "ai_reports_table_arn" {
   value       = aws_dynamodb_table.ai_reports.arn
 }
 
+# AI Review (F3) — season-memory table outputs (mirror reports table above)
+output "ai_memories_table_name" {
+  description = "DynamoDB table name for AI Review season memories"
+  value       = aws_dynamodb_table.ai_memories.name
+}
+
+output "ai_memories_table_arn" {
+  description = "DynamoDB table ARN for AI Review season memories"
+  value       = aws_dynamodb_table.ai_memories.arn
+}
+
 # Route53
 output "route53_zone_id" {
   description = "Route53 hosted zone ID"


### PR DESCRIPTION
## Summary

F3 (weekly recap) infrastructure portion of the AI Review epic. Three terraform additions:

- **New DynamoDB table** `xomper-ai-memories` — stores Claude-generated season memories appended every Tuesday. PK `LEAGUE#<league_id>#SEASON#<year>`, SK `MEMORY#<week:02d>#<memory_id>`. PAY_PER_REQUEST + KMS + PITR mirroring `xomper-ai-reports`. **No GSI in v1** — the only access pattern is `PK + SK begins_with MEMORY#` with `ScanIndexForward=false`, which works on the base table. Season-scoping in the PK means 2027 starts empty without manual purge.
- **New scheduled lambda + EventBridge rule** `notif-ai-review-weekly` — Tuesday afternoon AI newsletter cron. Stub function deployed by terraform, real code lands in the backend PR.
- **New admin API route** `POST /admin/ai-review-weekly-trigger` — for cron retries + dry-run calibration + week overrides. Stub lambda deployed by terraform, real code lands in the backend PR.

## Cron timing decision

The existing `lambdas_scheduled.tf` entries set `schedule_timezone = "America/New_York"`, so EventBridge interprets cron expressions in ET directly — no DST math needed (the recap arrives at 14:00 ET year-round).

Chose `cron(0 14 ? * TUE *)` America/New_York = **Tue 2pm ET** because:
- MNF ends ~23:30 ET Mon; Sleeper's `nfl_state.week` reliably increments by Tue morning
- 5h after the existing `notif-weekly-recap` (Tue 09:00 ET) — clear inbox separation
- 4h after `notif-worldcup-movement` (Tue 10:00 ET) — no operational collision
- Far enough into the day that even the West Coast / cross-country travelers see it land in inbox during work hours

## IAM

Existing `${var.app_name}*` wildcards on `xomper-lambda-exec` cover:
- Dynamo R/W on `xomper-ai-memories` (DynamoDBRuntime statement)
- New `notif-ai-review-weekly` + `api-admin-ai-review-weekly-trigger` lambda invocation + log groups
- SSM read of `/xomper/api/ANTHROPIC_API_KEY`
- SES + SNS for hybrid email + push delivery

A one-line code-comment was added in `iam_lambdas.tf:DynamoDBRuntime` confirming `xomper-ai-memories` coverage. No statement edits.

## Plan summary

Local plan (against real remote state, with dummy var values):

\`\`\`
Plan: 15 to add, 15 to change, 1 to destroy.
\`\`\`

F3-specific additions (the 15 "to add"):
- `aws_dynamodb_table.ai_memories`
- `aws_cloudwatch_event_rule.scheduled_notif["notif-ai-review-weekly"]`
- `aws_cloudwatch_event_target.scheduled_notif["notif-ai-review-weekly"]`
- `aws_lambda_function.scheduled["notif-ai-review-weekly"]` (stub)
- `aws_lambda_permission.scheduled_notif_invoke["notif-ai-review-weekly"]`
- `aws_lambda_function.api["admin-ai-review-weekly-trigger"]` (stub)
- 7x API GW resources for `/admin/ai-review-weekly-trigger` (resource + method + integration + options preflight + invoke permission)

The "1 to destroy" is `module.api.aws_api_gateway_deployment.deploy` being replaced — standard behavior when new API GW routes are added. The "15 to change" are the SSM parameters being touched by re-encryption noise from dummy var values during the local plan; CI plan with real secret values will not show those.

## Notes

- F3 plan: `xomper-ios/docs/features/ai-review/f3-weekly/PLAN.md`
- Tracked under issue [Xomware/xomper-ios#79](https://github.com/Xomware/xomper-ios/issues/79)
- Depends on F0 (#80), F1 (#103/#58/#83), F2 (#104/#105/#59) — all shipped per plan header
- Follows: backend PR adds the two lambda dirs over these stubs, then iOS PR adds the AdminView trigger card
- No state migrations; no destructive changes; no IAM additions

## Test plan

- [ ] CI: `terraform fmt` clean
- [ ] CI: `terraform validate` clean
- [ ] CI: `terraform plan` posts to PR; reviewer confirms F3-only adds (no surprise destroys outside the API GW deployment replace)
- [ ] Merge → CI runs `terraform apply` (Xomware rule: never apply locally)
- [ ] Post-apply: `aws dynamodb describe-table --table-name xomper-ai-memories` returns the table with KMS + PITR
- [ ] Post-apply: `aws events list-rules --name-prefix xomper-notif-ai-review-weekly` returns the rule with `cron(0 14 ? * TUE *)` + `America/New_York`
- [ ] Post-apply: API GW console shows `POST /admin/ai-review-weekly-trigger` route returning 502 (stub) until backend ships
- [ ] No regression on F0/F1/F2 routes (`/ai-reports/list`, `/ai-reports/latest`, `/admin/ai-review-postdraft-trigger`, `/admin/ai-review-preseason-trigger`)