### PR TITLE
feat(admin-portal F1): infra — test email + recipients API routes

### DIFF
--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -88,6 +88,18 @@ locals {
     # lambda + xomper-ai-memories R/W — no IAM changes needed.
     { name = "admin-ai-review-weekly-trigger", description = "AI Review: weekly recap admin trigger (cron retries + dry-run calibration)", path_part = "ai-review-weekly-trigger", http_method = "POST" },
 
+    # Admin Portal (F1) — test email sender + recipients picker.
+    # Lets an admin re-send any of the latest AI Review reports to a single
+    # whitelisted user without polluting broadcast state. Same JWT + admin gate
+    # as the other /admin/* routes (shared authorizer + handler-level
+    # require_admin). Backend dirs:
+    #   lambdas/api_admin_email_test/             → xomper-api-admin-email-test
+    #   lambdas/api_admin_email_test_recipients/  → xomper-api-admin-email-test-recipients
+    # IAM coverage: existing wildcards on xomper-lambda-exec (Dynamo R/W, SSM
+    # read, SES, Supabase via env) already cover both lambdas — no IAM changes.
+    { name = "admin-email-test", description = "Admin: send a single AI Review report to one whitelisted user", path_part = "email-test", http_method = "POST" },
+    { name = "admin-email-test-recipients", description = "Admin: list whitelisted users for the test-email picker", path_part = "email-test-recipients", http_method = "GET" },
+
     # AI Review (F0) — paginated archive + latest-by-type reads.
     # Routes land at /ai-reports/latest and /ai-reports/list under the new
     # `ai-reports` API GW service block (see api_gateway.tf). Query params


### PR DESCRIPTION
## Summary

Phase A (infra) of the Admin Portal F1 epic — adds 2 new admin API routes:

- `POST /admin/email-test` → `xomper-api-admin-email-test` (backend: `lambdas/api_admin_email_test/`)
- `GET  /admin/email-test-recipients` → `xomper-api-admin-email-test-recipients` (backend: `lambdas/api_admin_email_test_recipients/`)

Both routes mirror the existing F1/F2/F3 admin-trigger pattern verbatim: stub lambda created here, real handler code overlaid by the backend deploy (PR #2 in the F1 triplet). They auto-wire to the `/admin/*` service block via the existing `startswith(l.name, "admin-")` filter in `api_gateway.tf` — no `api_gateway.tf` edit needed.

JWT + admin gate inherited from the shared authorizer (`lambda_authorizer.tf`) plus handler-level `require_admin`. No IAM, DynamoDB, SSM, or CloudWatch changes — existing `xomper-lambda-exec` wildcards (Dynamo R/W, SSM read, SES, Supabase env) already cover both new lambdas.

Closes #91 (Phase A).

## Plan summary (local, with dummy var values)

Net F1-attributable changes:
- **19 to add** — 2 lambdas + 2 API GW resources + 2 methods + 2 integrations + 2 method responses + 2 lambda permissions + 2 OPTIONS preflight resources + 1 deployment refresh + edge resources for the new routes.
- **0 to change** attributable to this PR (all 16 in-place updates in the local plan are SSM/cert tag drift caused by dummy `TF_VAR_*` values — they will not appear in the real CI plan with GitHub Secrets).
- **0 to destroy** attributable to this PR (the 1 destroy in the local plan is the API GW deployment being replaced — expected when adding new routes).

CI will produce the canonical plan against real secrets — verify before merge.

## Plan reference

- Feature plan: `xomper-ios/docs/features/admin-portal/f1-test-email/PLAN.md`
- Epic plan: `xomper-ios/docs/features/admin-portal/EPIC_PLAN.md`

## Test plan

- [ ] CI `terraform plan` shows ONLY the 19 F1-attributable adds + 1 API GW deployment replace (no SSM/cert drift in CI plan).
- [ ] After merge: CI apply succeeds; `aws apigateway get-resources` confirms both new path parts (`email-test`, `email-test-recipients`) under the admin resource.
- [ ] Stub lambdas `xomper-api-admin-email-test` and `xomper-api-admin-email-test-recipients` exist and return 502 until backend PR #2 overlays real code.