### PR TITLE
feat(admin-portal F3): infra — reports-flag API route

### DIFF
--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -100,6 +100,20 @@ locals {
     { name = "admin-email-test", description = "Admin: send a single AI Review report to one whitelisted user", path_part = "email-test", http_method = "POST" },
     { name = "admin-email-test-recipients", description = "Admin: list whitelisted users for the test-email picker", path_part = "email-test-recipients", http_method = "GET" },
 
+    # Admin Portal (F3) — toggle is_redacted / do_not_broadcast metadata flags on
+    # an AI report row. The api-gateway-service v2.2.0 module supports only
+    # `path_prefix` + `path_part` (two-segment paths) so the route is flattened
+    # under the existing `admin` service block as `/admin/reports-flag` (mirrors
+    # the F1/F2 admin-trigger flatten pattern, e.g. ai-review-postdraft-trigger).
+    # league_id / report_type / period are passed in the JSON body instead of
+    # path params. Same JWT + admin gate as other /admin/* routes (shared
+    # authorizer + handler-level require_admin). Backend dir:
+    #   lambdas/api_admin_reports_flag/  → xomper-api-admin-reports-flag
+    # IAM coverage: existing wildcards on xomper-lambda-exec (Dynamo R/W on
+    # xomper-ai-reports, SSM read, Supabase via env) already cover the new
+    # lambda — no IAM changes needed.
+    { name = "admin-reports-flag", description = "Admin: toggle is_redacted / do_not_broadcast on an AI report row (body: league_id, report_type, period, flag, value)", path_part = "reports-flag", http_method = "POST" },
+
     # AI Review (F0) — paginated archive + latest-by-type reads.
     # Routes land at /ai-reports/latest and /ai-reports/list under the new
     # `ai-reports` API GW service block (see api_gateway.tf). Query params


### PR DESCRIPTION
## Summary

- Adds `POST /admin/reports-flag` via one new entry in `local.api_lambdas` (`lambdas_api.tf`). Routes the F3 redact + do-not-broadcast flag toggle endpoint.
- Path flattened to a single segment because the `api-gateway-service` v2.2.0 module supports only two path segments. `league_id` / `report_type` / `period` move into the JSON body. Mirrors the F1/F2 admin-trigger flatten pattern (e.g. `/admin/ai-review-postdraft-trigger`).
- No IAM, Dynamo, SSM, or CloudWatch changes. The existing `xomper-lambda-exec` role wildcards already cover Dynamo R/W on `xomper-ai-reports`, SSM read, and Supabase env access.

Related:
- Closes #91
- F3 plan: `docs/features/admin-portal/f3-redact/PLAN.md` (in `xomper-ios`)
- Epic plan: `docs/features/admin-portal/EPIC_PLAN.md`

## Plan summary

Local `terraform plan` (filtered to the F3 resources) shows **9 new resources** scoped under `admin-reports-flag`:

```
# aws_lambda_function.api["admin-reports-flag"]                              (new)
# module.api.aws_api_gateway_resource.endpoint["admin/admin-reports-flag"]   (new)
# module.api.aws_api_gateway_method.endpoint["admin/admin-reports-flag"]     (new)
# module.api.aws_api_gateway_integration.endpoint["admin/admin-reports-flag"] (new)
# module.api.aws_api_gateway_method.options["admin/admin-reports-flag"]      (new, CORS preflight)
# module.api.aws_api_gateway_method_response.options["admin/admin-reports-flag"] (new, CORS)
# module.api.aws_api_gateway_integration.options["admin/admin-reports-flag"] (new, CORS)
# module.api.aws_api_gateway_integration_response.options["admin/admin-reports-flag"] (new, CORS)
# module.api.aws_lambda_permission.invoke["admin/admin-reports-flag"]        (new)
```

Plus an expected in-place update to `module.api.aws_api_gateway_stage.stage` (new deployment id) — same as every prior endpoint add (F1 / F2 PRs followed identical shape).

## Test plan

- [ ] CI `terraform plan` job posts the same 9 new resources (no extras, no destroys).
- [ ] After merge, `terraform.yml` apply job succeeds.
- [ ] Verify `POST /admin/reports-flag` exists on the dev stage via `aws apigateway get-resources --rest-api-id <id> | jq '.items[] | select(.pathPart=="reports-flag")'`.
- [ ] Backend PR (next) wires the `xomper-api-admin-reports-flag` handler — F3 backend phase will validate end-to-end.