### PR TITLE
fix(infra): F3 weekly cron fires Tue 2pm ET (UTC equivalent)

### DIFF
--- a/terraform/lambdas_scheduled.tf
+++ b/terraform/lambdas_scheduled.tf
@@ -7,8 +7,14 @@
 # Supabase + Sleeper, and emits push (and optionally email) via the
 # existing send_push_to_users / send_emails_concurrently infra.
 #
-# Schedules use the America/New_York timezone (EventBridge supports
-# this since 2023, no manual DST handling required).
+# TODO: aws_cloudwatch_event_rule does NOT support schedule_timezone.
+# All schedule_timezone fields in local.scheduled_lambdas are ignored.
+# Other crons (notif-weekly-recap, notif-lineup-not-set, notif-close-game-*,
+# notif-worldcup-movement) currently fire at the UTC time in their cron
+# expression — left as-is for v1 since the user has been running with
+# this behavior. To fix properly, migrate to `aws_scheduler_schedule`
+# which natively supports timezone — or convert each cron expression
+# to its UTC equivalent like the F3 entry below.
 ###############################################################################
 
 locals {
@@ -49,19 +55,26 @@ locals {
       schedule_timezone = "America/New_York"
     },
     # AI Review (F3) — weekly recap cron.
-    # Fires Tue 14:00 ET — far enough past Monday Night Football (~23:30 ET
-    # Mon) for Sleeper's nfl_state.week to have incremented, and 5h past
-    # `notif-weekly-recap` (09:00 ET) so the two products land separately
-    # in inboxes. ET is interpreted directly by EventBridge via
-    # schedule_timezone, so no DST math needed (same convention as the
-    # other five entries above).
+    # Fires Tue 18:00 UTC, which lands post-MNF (~23:30 ET Mon) so Sleeper's
+    # nfl_state.week has incremented, and several hours past `notif-weekly-recap`
+    # so the two products land separately in inboxes.
+    #
+    # Cron expression is in UTC because aws_cloudwatch_event_rule does NOT
+    # support schedule_timezone (see the TODO at the top of this file — the
+    # schedule_timezone attribute below is silently ignored by AWS). To get
+    # ET-aware behavior without migrating resources we encode the UTC time
+    # directly, which means DST drift is acceptable for this cron:
+    #   - 18:00 UTC = 14:00 EDT during EDT window (Mar–Nov, regular season)
+    #   - 18:00 UTC = 13:00 EST during EST window (Nov–Mar, playoffs)
+    # Both windows are post-lunch Tuesday — fine for a weekly newsletter.
+    #
     # IAM coverage: existing wildcards in iam_lambdas.tf cover the new
     # function name + Dynamo R/W on xomper-ai-memories / xomper-ai-reports.
     {
       name              = "notif-ai-review-weekly"
       handler_dir       = "notif_ai_review_weekly"
       description       = "Tuesday afternoon: AI-generated weekly league newsletter (Claude Haiku)"
-      cron_expression   = "cron(0 14 ? * TUE *)" # Tue 14:00 ET, post-MNF
+      cron_expression   = "cron(0 18 ? * TUE *)" # Tue 18:00 UTC = 2pm EDT / 1pm EST
       schedule_timezone = "America/New_York"
     },
   ]


### PR DESCRIPTION
## Summary

`aws_cloudwatch_event_rule` does **not** support `schedule_timezone` — that attribute is only honored on the newer `aws_scheduler_schedule` resource. Every entry in `local.scheduled_lambdas` has been silently firing at the UTC time encoded in its cron expression instead of America/New_York as the comments claimed.

This PR fixes only the F3 weekly AI Review cron (`notif-ai-review-weekly`) by converting its cron expression to the UTC equivalent. The other 5 crons have the same bug but the user has been running with their current behavior for a year — left a TODO comment for them.

## The change

- F3 cron: `cron(0 14 ? * TUE *)` → `cron(0 18 ? * TUE *)`
  - 18:00 UTC = **14:00 EDT** during EDT (Mar–Nov, regular season Sep–early Nov)
  - 18:00 UTC = **13:00 EST** during EST (Nov–Mar, playoffs Nov–Dec)
  - Drift is acceptable: both windows are post-lunch Tuesday — fine for a weekly newsletter, and still safely post-MNF (~23:30 ET Mon) so Sleeper's `nfl_state.week` has incremented.
- Updated the F3 entry's comment block to explain the bug + DST drift.
- Added a TODO at the top of `lambdas_scheduled.tf` referencing the broader bug and the two fix paths (migrate to `aws_scheduler_schedule` for native timezone support, or convert each cron to its UTC equivalent like F3).

## Scope

- **Only F3.** The other 5 crons (`notif-weekly-recap`, `notif-lineup-not-set`, `notif-close-game-sun`, `notif-close-game-mon`, `notif-worldcup-movement`) are intentionally **not** touched in this PR — they've been firing at their UTC times for a year and the user is used to the current behavior. Tracked via the TODO block.
- No IAM changes, no new resources, no resource renames.

## Plan summary

```
~ aws_cloudwatch_event_rule.scheduled_notif["notif-ai-review-weekly"]
    schedule_expression = "cron(0 14 ? * TUE *)" -> "cron(0 18 ? * TUE *)"

Plan: 0 to add, 1 to change, 0 to destroy.
```

(Run locally with `-target` on the F3 rule + dummy `-var` values for secrets; real plan runs in the CI workflow against TF_VAR_* GitHub Secrets.)

## Test plan

- [ ] CI `terraform plan` shows exactly 1 change (the F3 rule's `schedule_expression`).
- [ ] After merge + apply, verify in AWS console: `xomper-notif-ai-review-weekly-schedule` shows `cron(0 18 ? * TUE *)`.
- [ ] Next Tuesday: confirm lambda invocation timestamp in CloudWatch Logs is ~18:00 UTC (14:00 ET while EDT is in effect).