### PR TITLE
feat(admin-cron-settings): infra — list + update API routes

### DIFF
--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -136,6 +136,23 @@ locals {
     { name = "admin-leagues-list", description = "Admin: list whitelisted_leagues (full rows for the Tables editor)", path_part = "leagues-list", http_method = "GET" },
     { name = "admin-audit-list", description = "Admin: paginated audit feed from admin_audit (query ?limit=&cursor=&action=&actor_user_id=)", path_part = "audit-list", http_method = "GET" },
 
+    # Admin Cron Settings — per-lambda Enabled kill switch + Test Mode flag for
+    # the five scheduled notif lambdas (notif_weekly_recap, notif_lineup_not_set,
+    # notif_close_game_alert, notif_worldcup_movement, notif_ai_review_weekly).
+    # Backed by a new `admin_cron_settings` Supabase table (created out-of-band
+    # via the Supabase dashboard — no Terraform changes for the table itself).
+    # Routes flattened under the existing `admin` service block per the same
+    # api-gateway-service v2.2.0 constraint as F1/F3/F4 above. Same JWT + admin
+    # gate as other /admin/* routes (shared authorizer + handler-level
+    # require_admin). Update writes an `admin_audit` row. Backend dirs:
+    #   lambdas/api_admin_cron_settings_list/    → xomper-api-admin-cron-settings-list
+    #   lambdas/api_admin_cron_settings_update/  → xomper-api-admin-cron-settings-update
+    # IAM coverage: existing wildcards on xomper-lambda-exec (Dynamo R/W, SSM
+    # read, SES, Supabase via env) already cover the new lambdas — no IAM
+    # changes needed.
+    { name = "admin-cron-settings-list", description = "Admin: list all admin_cron_settings rows (enabled + test_mode per cron)", path_part = "cron-settings-list", http_method = "GET" },
+    { name = "admin-cron-settings-update", description = "Admin: patch enabled / test_mode on a single admin_cron_settings row (body: cron_key, enabled?, test_mode?)", path_part = "cron-settings-update", http_method = "POST" },
+
     # Admin Portal (F5) — CloudWatch Log Viewer. Reads a tail of admin-relevant
     # lambda log groups via `logs:FilterLogEvents` and returns paginated events
     # with server-side PII redaction (email / Sleeper user id / Anthropic key).


### PR DESCRIPTION
## Summary

Adds two new admin-gated API GW routes wiring the iOS Cron Settings sub-screen to the new backend lambdas:

- `GET  /admin/cron-settings-list` → `xomper-api-admin-cron-settings-list`
- `POST /admin/cron-settings-update` → `xomper-api-admin-cron-settings-update`

Both flattened under `/admin/*` per the existing api-gateway-service v2.2.0 constraint (mirrors the F1/F3/F4 admin-trigger flatten pattern, e.g. `email-test`, `reports-flag`, `users-update`, `audit-list`). Same JWT + admin gate as other `/admin/*` routes (shared authorizer + handler-level `require_admin`).

No IAM changes — existing wildcards on `xomper-lambda-exec` cover the new lambdas (Supabase reads via env vars, same pattern as the F4 admin-table-edit lambdas).

Plan reference: `xomper-ios/docs/features/admin-cron-settings/PLAN.md`

## Manual step required before backend lambdas function

The `admin_cron_settings` Supabase table is created out-of-band via the Supabase dashboard (same pattern as F4's `admin_audit`). The SQL migration is committed in `xomper-back-end/sql/admin_cron_settings_migration.sql` (Phase 2 PR) and must be applied to Supabase before the new lambdas can read/write the table. The shared helper defaults to `{enabled: True, test_mode: False}` on Supabase failure, so a missing table won't break the existing notif lambdas — they will continue to behave as today until the migration is applied.

## Plan summary (local, with dummy var values)

- Add: 19 (2 lambdas + their full API GW wiring: 2 resources, 2 methods, 2 integrations, 2 lambda permissions, 2 OPTIONS methods + responses + integrations for CORS)
- Change: 15 (all in-place no-ops in CI — SSM params + ACM cert + APNs platform app + IAM role policy + API GW domain/stage; appear changed locally only because dummy var values were used for the plan)
- Destroy: 1 (`module.api.aws_api_gateway_deployment.deploy` recreated — standard behavior when adding new routes)

The 2-add expectation from the plan refers to the conceptual route entries; under the hood each route entry expands to ~9-10 child resources in the `api-gateway-service` module.

## Test plan

- [ ] CI `terraform plan` review confirms only the 2 new routes + their wiring are created (no spurious changes once real `TF_VAR_*` secrets are used)
- [ ] After merge + apply, hit `GET https://api.xomware.com/admin/cron-settings-list` with admin JWT → expect 502 (lambda stub) until Phase 2 backend PR lands
- [ ] After Phase 2 backend deploy + manual Supabase migration, expect 200 with 5 seeded rows