### PR TITLE
feat(announcements): infra — public read + admin CRUD API routes

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -39,6 +39,18 @@ locals {
       invoke_arn  = aws_lambda_function.api[l.name].invoke_arn
     } if startswith(l.name, "ai-reports-")
   ]
+
+  # Public-read announcements endpoint(s). Filtered by exact name == "announcements"
+  # so we do NOT accidentally include the four admin-announcements-* lambdas
+  # (those live under the /admin/* service block above).
+  announcements_endpoints = [
+    for l in local.api_lambdas : {
+      name        = l.name
+      path_part   = l.path_part
+      http_method = l.http_method
+      invoke_arn  = aws_lambda_function.api[l.name].invoke_arn
+    } if l.name == "announcements"
+  ]
 }
 
 module "api" {
@@ -73,6 +85,10 @@ module "api" {
     ai_reports = {
       path_prefix = "ai-reports"
       endpoints   = local.ai_reports_endpoints
+    }
+    announcements = {
+      path_prefix = "announcements"
+      endpoints   = local.announcements_endpoints
     }
     # New API services (profiles, rules, etc.) will be added during Supabase migration
   }

--- a/terraform/lambdas_api.tf
+++ b/terraform/lambdas_api.tf
@@ -178,6 +178,34 @@ locals {
     #   lambdas/api_ai_reports_list/    → xomper-api-ai-reports-list
     { name = "ai-reports-latest", description = "AI Review: latest report by type (query ?type=postDraft|preseason|weekly)", path_part = "latest", http_method = "GET" },
     { name = "ai-reports-list", description = "AI Review: paginated archive (query ?type=&limit=&cursor=)", path_part = "list", http_method = "GET" },
+
+    # Announcements — admin-editable league announcements replacing the
+    # hardcoded LeagueAnnouncements.current array shipped in Season Refocus F2.
+    # One public read (JWT-gated, not admin-gated) plus four admin-gated
+    # CRUD routes. Backed by a new `league_announcements` Supabase table
+    # (created out-of-band via the Supabase dashboard — no Terraform changes
+    # for the table itself). Public read lands at /announcements/list under
+    # the new `announcements` API GW service block (see api_gateway.tf),
+    # mirroring the F0 ai-reports two-segment flatten for the same
+    # api-gateway-service v2.2.0 constraint (path_prefix + path_part only).
+    # The four admin routes flatten under the existing `admin` service block
+    # per the F1/F3/F4 admin-flatten pattern (email-test, reports-flag,
+    # users-update, ...). Same JWT + admin gate as other /admin/* routes
+    # (shared authorizer + handler-level require_admin). Write handlers
+    # append an `admin_audit` row. Backend dirs:
+    #   lambdas/api_announcements/                    → xomper-api-announcements
+    #   lambdas/api_admin_announcements_list/         → xomper-api-admin-announcements-list
+    #   lambdas/api_admin_announcements_create/       → xomper-api-admin-announcements-create
+    #   lambdas/api_admin_announcements_update/       → xomper-api-admin-announcements-update
+    #   lambdas/api_admin_announcements_delete/       → xomper-api-admin-announcements-delete
+    # IAM coverage: existing wildcards on xomper-lambda-exec (Dynamo R/W,
+    # SSM read, SES, Supabase via env) already cover the new lambdas — no
+    # IAM changes needed.
+    { name = "announcements", description = "Announcements: list active league announcements (public read, JWT-gated)", path_part = "list", http_method = "GET" },
+    { name = "admin-announcements-list", description = "Admin: list all league_announcements rows (full rows incl. inactive/expired for the editor)", path_part = "announcements-list", http_method = "GET" },
+    { name = "admin-announcements-create", description = "Admin: create a league_announcements row (body: title, body, priority, expires_at?, is_active?, display_order?)", path_part = "announcements-create", http_method = "POST" },
+    { name = "admin-announcements-update", description = "Admin: patch an allowlisted-field subset of a league_announcements row (body: id, fields)", path_part = "announcements-update", http_method = "POST" },
+    { name = "admin-announcements-delete", description = "Admin: soft-delete a league_announcements row by id (sets is_active=false; body: id)", path_part = "announcements-delete", http_method = "POST" },
   ]
 }
 


### PR DESCRIPTION
## Summary

Adds five new API GW routes for the admin-editable league announcements feature — one public read plus four admin-gated CRUD routes. Mirrors the F4 admin-flatten pattern for the four admin routes and the F0 ai-reports new-service-block pattern for the public read.

Closes #100 (infra portion only — backend + iOS land in follow-up PRs).

Plan: `xomper-ios/docs/features/announcements/PLAN.md` (Status: Ready)

## Routes added

| Method | Path                            | Auth         | Lambda dir                                |
|--------|---------------------------------|--------------|-------------------------------------------|
| GET    | `/announcements/list`           | JWT only     | `lambdas/api_announcements/`              |
| GET    | `/admin/announcements-list`     | JWT + admin  | `lambdas/api_admin_announcements_list/`   |
| POST   | `/admin/announcements-create`   | JWT + admin  | `lambdas/api_admin_announcements_create/` |
| POST   | `/admin/announcements-update`   | JWT + admin  | `lambdas/api_admin_announcements_update/` |
| POST   | `/admin/announcements-delete`   | JWT + admin  | `lambdas/api_admin_announcements_delete/` |

### Note on the public path

The plan calls the public route `GET /announcements`, but the shared `api-gateway-service` module (v2.2.0) only supports two-segment routes (`path_prefix` + `path_part`). Per the same constraint that forced the F0 ai-reports flatten to `/ai-reports/list` / `/ai-reports/latest`, the public read here is served at `GET /announcements/list`. The iOS + backend PRs that follow will hit `/announcements/list`. This matches the plan's "Path-flattened per existing convention" directive.

## Auth model

- Public read (`GET /announcements/list`): shared JWT authorizer rejects unauthenticated requests; no admin claim required. Any signed-in league member can call it.
- All four `/admin/*` routes: shared JWT authorizer plus handler-level `require_admin` check (mirrors F1/F3/F4 admin handlers). Non-admin tokens get 403 at the handler.

## IAM coverage

No changes. Existing wildcards on `xomper-lambda-exec` (Dynamo R/W, SSM read, SES, Supabase via env) already cover the five new lambdas. Confirmed in inline comments in `terraform/lambdas_api.tf`.

## terraform plan summary (announcement-related)

- 5 new `aws_lambda_function.api` entries (one per route)
- 5 new `aws_api_gateway_resource.endpoint`
- 5 new `aws_api_gateway_method.endpoint` (+ 5 corresponding OPTIONS for CORS)
- 5 new `aws_api_gateway_integration.endpoint`
- 5 new `aws_lambda_permission.invoke`
- 1 new `aws_api_gateway_resource.service` (`announcements`)
- 1 forced replacement of `aws_api_gateway_deployment.deploy` (every new-route PR triggers this — standard behavior across all prior infra PRs)

Locally validated with `terraform validate` (clean) and `terraform plan` (announcement resources match the table above; the other 15 in-place changes shown locally are dummy-var noise that won't appear in the CI plan run with real GitHub Secrets).

## Test plan

- [ ] CI `terraform plan` run on this PR shows 5 new lambdas + 5 new routes + 1 service block + 1 deployment replacement, and zero unrelated drift
- [ ] After merge + apply, smoke `GET /announcements/list` with a valid JWT returns 200 (handler returns 501 / empty until the backend PR lands — fine, the route should still 200 through API GW to the stub lambda)
- [ ] Smoke an admin route with a non-admin JWT returns 403 (handler-level guard, again backend-PR-dependent)
- [ ] No drift on prior infra (lambdas, IAM, SSM, ACM, API GW stage)