### PR TITLE
fix(api-gw): unset authorizerCredentials so authorizer can actually be invoked

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -61,7 +61,15 @@ module "api" {
   # there is a custom domain base path mapping that depends on this stage name.
   stage_name            = "dev"
   authorizer_invoke_arn = aws_lambda_function.authorizer.invoke_arn
-  authorizer_role_arn   = aws_iam_role.authorizer_role.arn
+  # Pass empty so the module skips authorizerCredentials. With it
+  # unset, API GW invokes the authorizer via the Lambda's
+  # resource-based policy (module.api.aws_lambda_permission.authorizer)
+  # instead of trying to assume this role. The role we previously
+  # passed here (xomper-authorizer-exec) is the authorizer Lambda's
+  # *execution* role — it trusts lambda.amazonaws.com only and has no
+  # InvokeFunction permission, which caused AuthorizerConfigurationException
+  # on every authorized request after the 2026-06-01 deployment replacement.
+  authorizer_role_arn   = ""
   tags                  = local.standard_tags
   allow_headers         = local.api_allow_headers
   allow_origin          = "https://${local.domain_name}"


### PR DESCRIPTION
## Root cause
The api-gateway-service module wires the \`authorizerCredentials\` field on the API GW authorizer from \`var.authorizer_role_arn\`. We were passing \`aws_iam_role.authorizer_role.arn\` — but \`xomper-authorizer-exec\` is the Lambda's **execution** role, not an *invoke* role:

- **Trust policy**: \`lambda.amazonaws.com\` only (not API Gateway)
- **Permissions**: CloudWatch logs / SSM / KMS / X-Ray — no \`lambda:InvokeFunction\`

When \`authorizerCredentials\` is set, API GW assumes that role to invoke the authorizer and **ignores** the resource-based policy. Role assumption fails → \`AuthorizerConfigurationException\` → HTTP 500 on every authorized request.

The bug was latent until the 2026-06-01 deployment replacement (the \`admin-users-list\` change forced \`aws_api_gateway_deployment\` to be replaced) re-evaluated the authorizer wiring.

## Fix
Pass empty string so the module skips emitting \`authorizerCredentials\`. With it unset, API GW falls back to the Lambda's resource-based policy — \`module.api.aws_lambda_permission.authorizer\` (\`AllowExecFromAPIGateway\`) — which is already correctly scoped to allow \`apigateway.amazonaws.com\` to invoke the function for this API.

## Test plan
- [ ] terraform plan: one change — \`module.api.aws_api_gateway_authorizer.authorizer\` updates \`authorizer_credentials\` to empty
- [ ] After apply: \`curl -H "Authorization: Bearer fake" https://api.xomper.xomware.com/admin/audit-list\` returns **403** (authorizer deny), not 500
- [ ] iOS Admin → Audit / Tables / Test Email load real data on TestFlight v2.31.3 (no app rebuild needed)