### PR TITLE
feat(authorizer): expose SUPABASE_URL for JWKS-based JWT verification

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -19,6 +19,8 @@ locals {
     FROM_EMAIL           = var.from_email
     SNS_PLATFORM_APP_ARN = aws_sns_platform_application.apns.arn
     DEVICE_TOKENS_TABLE  = aws_dynamodb_table.device_tokens.name
+    # Authorizer needs this to fetch Supabase's JWKS for ES256 verification.
+    SUPABASE_URL         = var.supabase_url
   }
 
   # API GW


### PR DESCRIPTION
Pairs with xomper-back-end PR rewriting the authorizer to verify Supabase ES256 JWTs via JWKS. Adds `SUPABASE_URL` to `local.lambda_variables` so the authorizer Lambda can fetch `{SUPABASE_URL}/auth/v1/.well-known/jwks.json` at module load.

## Why
Authorizer log says `Authorizer: invalid token - The specified alg value is not allowed`. Supabase's published JWKS (curl-confirmed) has `alg: ES256`. The current handler hard-codes `algorithms=['HS256']` with secret "xomper" — it can never verify a real Supabase token. Every authorized endpoint has been returning 403 for this reason.

## Deploy order
Merge **this PR first**, then the xomper-back-end PR. Reverse order leaves the new handler reading a missing env var → denies everything.