### PR TITLE
fix(authorizer): pin runtime to python3.10 so cryptography imports for ES256 JWT verification

### DIFF
--- a/terraform/lambda_authorizer.tf
+++ b/terraform/lambda_authorizer.tf
@@ -6,7 +6,14 @@ resource "aws_lambda_function" "authorizer" {
   source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
   handler          = "handler.handler"
   layers           = [aws_lambda_layer_version.lambda_layer.arn]
-  runtime          = var.lambda_runtime
+  # Pinned to python3.10 because the shared layer
+  # (xomper-shared-packages) is compiled with cp310 extensions
+  # (notably _cffi_backend.cpython-310-x86_64-linux-gnu.so used
+  # transitively by cryptography). The authorizer is the only
+  # lambda that imports cryptography (via PyJWT's ES256 path for
+  # Supabase JWT verification); all other lambdas work fine on
+  # var.lambda_runtime (3.13) because they don't touch cryptography.
+  runtime          = "python3.10"
   memory_size      = var.authorizer_memory_size
   timeout          = var.authorizer_timeout
   role             = aws_iam_role.authorizer_role.arn


### PR DESCRIPTION
## Verified root cause
Authorizer log shows real Supabase JWTs reaching the lambda and being rejected with:

```
Authorizer: decode error - The JWK Set did not contain any usable keys. Perhaps 'cryptography' is not installed?
```

Traced to PyJWT's `algorithms.py` — it does `try: from cryptography... except ModuleNotFoundError: has_crypto = False`. With `has_crypto=False`, ES256 algorithm isn't registered → every EC key in the JWKS is 'unusable'.

The shared layer is compiled with python3.10 extensions:
```
xomper-shared-packages:51 CompatibleRuntimes: ["python3.10"]
_cffi_backend.cpython-310-x86_64-linux-gnu.so
```

The authorizer was running python3.13 (per `var.lambda_runtime`). On 3.13, the cp310 cffi binding doesn't load → cryptography import chain fails → ModuleNotFoundError → has_crypto=False.

## Fix
Pin just the authorizer to python3.10. All other lambdas keep 3.13 because they don't import cryptography (boto3 ships with the Lambda runtime).

## Test
- [ ] terraform apply: only `aws_lambda_function.authorizer` runtime changes
- [ ] After apply: `/admin/audit-list` with a real Supabase JWT returns 200 (or 403 from admin_gate, not from authorizer)