### PR TITLE
revert: unpin authorizer runtime — layer now built for python 3.13

### DIFF
--- a/terraform/lambda_authorizer.tf
+++ b/terraform/lambda_authorizer.tf
@@ -6,14 +6,7 @@ resource "aws_lambda_function" "authorizer" {
   source_code_hash = filebase64sha256("./templates/lambda_stub.zip")
   handler          = "handler.handler"
   layers           = [aws_lambda_layer_version.lambda_layer.arn]
-  # Pinned to python3.10 because the shared layer
-  # (xomper-shared-packages) is compiled with cp310 extensions
-  # (notably _cffi_backend.cpython-310-x86_64-linux-gnu.so used
-  # transitively by cryptography). The authorizer is the only
-  # lambda that imports cryptography (via PyJWT's ES256 path for
-  # Supabase JWT verification); all other lambdas work fine on
-  # var.lambda_runtime (3.13) because they don't touch cryptography.
-  runtime          = "python3.10"
+  runtime          = var.lambda_runtime
   memory_size      = var.authorizer_memory_size
   timeout          = var.authorizer_timeout
   role             = aws_iam_role.authorizer_role.arn


### PR DESCRIPTION
Pairs with xomper-back-end PR upgrading the shared layer build to python 3.13. With a 3.13-compatible layer, the authorizer can run on `var.lambda_runtime` (3.13) like the other lambdas.

## Merge order
Merge the backend PR first so the new 3.13 layer is published + every lambda is updated to it. Then merge this. Reverse order leaves authorizer briefly on 3.13 + old 3.10 layer → ES256 verification breaks.